### PR TITLE
Lowercase content-type

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function getRequestOptions(endpoint, fixture, baseUrl) {
   var contentType = endpoint.consumes ? endpoint.consumes[0] : 'application/json';
   reqOpts.method = fixture.method;
   reqOpts.url = '' + baseUrl + fixture.url;
-  reqOpts.headers['Content-type'] = contentType;
+  reqOpts.headers['content-type'] = contentType;
 
   (endpoint.parameters || []).forEach(function (param) {
     var value = fixture.request[param.name];


### PR DESCRIPTION
This ensures that the content-type of the request gets overwritten, otherwise there will be both a `Content-type` and `content-type` header which caused some issue for a test I am writing for `swagger-to-graphql`.